### PR TITLE
Support username/password in the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ xunithub -g https://api.github.com/repos/(org/repo) -k (Github Access Token) -p 
 
 xunithub -g https://api.github.com/repos/proverma/arrow -k XXXXXXXXXXXXXXXXXXXXXXX -p 4 -t ~/Work/test-xunit
 
+## Usage without API key
+
+If you do not want to use an API key, you can use a username and password, or username and MFA token, by including it in the repo url like so:
+
+xunithub -g https://username:password@api.github.com/repos/(org/repo) -p (Github PR ID) -t (Xunit Test folder)
+
+xunithub -g https://proverma:XXXXXXXX@api.github.com/repos/proverma/arrow -p 4 -t ~/Work/test-xunit
 
 ## Help
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var url = require('url')
             .alias('k','github-api-key')
             .alias('p','github-pr-id')
             .alias('t','test-report-folder')
-            .demand(['g','k','p','t'])
+            .demand(['g','p','t'])
             .argv
     , xunithub = require('./xunithub')
     , x = new xunithub()

--- a/xunithub.js
+++ b/xunithub.js
@@ -144,7 +144,6 @@ xunithub.prototype.postReport = function (failureList, githubRepoUrl, githubAPIk
             url: githubRepoUrl + '/issues/' +
             pullRequestID + '/comments',
             headers: {
-                'Authorization': 'token ' + githubAPIkey,
                 'Content-Type': 'application/json',
                 'User-Agent': 'git CL - node'
             },
@@ -152,9 +151,12 @@ xunithub.prototype.postReport = function (failureList, githubRepoUrl, githubAPIk
             json: {
                 body: errorData
             }
-
         }
         ;
+        
+    if (githubAPIkey) {
+        config.headers['Authorization'] = 'token ' + githubAPIkey;
+    }
     request(config, function (error, response) {
 
         if (!error && response.statusCode < 205) {


### PR DESCRIPTION
For HTTPS authentication, sometimes it's preferred to use account credentials over the API Key.  Xunithub already passes through the appropriately formatted url just fine, but the inclusion of a broken `Authorization` token causes an auth error.  This allows the auth token to be omitted.
